### PR TITLE
Updates gitignore to ignore the Config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Config
+/lib/config/Config.dart


### PR DESCRIPTION
Esse arquivo de Config é utilizado para guardar as API Keys.

Adiantando a adição dele para podermos navegar entre branches.